### PR TITLE
add session token parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,18 +70,18 @@ pipelines:
           # Type: string
           # Required: no
           aws.url: ""
-          # discovery polling period for the CDC mode of how often to check for
+          # Discovery polling period for the CDC mode of how often to check for
           # new shards in the DynamoDB Stream, formatted as a time.Duration
           # string.
           # Type: duration
           # Required: no
           discoveryPollingPeriod: "10s"
-          # records polling period for the CDC mode of how often to get new
+          # Records polling period for the CDC mode of how often to get new
           # records from a shard, formatted as a time.Duration string.
           # Type: duration
           # Required: no
           recordsPollingPeriod: "1s"
-          # skipSnapshot determines weather to skip the snapshot or not.
+          # SkipSnapshot determines weather to skip the snapshot or not.
           # Type: bool
           # Required: no
           skipSnapshot: "false"

--- a/README.md
+++ b/README.md
@@ -58,7 +58,10 @@ pipelines:
           # Type: string
           # Required: yes
           table: ""
-          # AWS temporary session token.
+          # AWS temporary session token. Note that to keep the connector running
+          # long-term, you should use an IAM user with no temporary session
+          # token. If the session token is used, then the connector will fail
+          # once it expires.
           # Type: string
           # Required: no
           aws.sessionToken: ""

--- a/README.md
+++ b/README.md
@@ -58,6 +58,10 @@ pipelines:
           # Type: string
           # Required: yes
           table: ""
+          # AWS temporary session token.
+          # Type: string
+          # Required: no
+          aws.sessionToken: ""
           # AWSURL The URL for AWS (useful when testing the connector with
           # localstack).
           # Type: string

--- a/connector.yaml
+++ b/connector.yaml
@@ -48,17 +48,17 @@ specification:
         default: ""
         validations: []
       - name: discoveryPollingPeriod
-        description: discovery polling period for the CDC mode of how often to check for new shards in the DynamoDB Stream, formatted as a time.Duration string.
+        description: Discovery polling period for the CDC mode of how often to check for new shards in the DynamoDB Stream, formatted as a time.Duration string.
         type: duration
         default: 10s
         validations: []
       - name: recordsPollingPeriod
-        description: records polling period for the CDC mode of how often to get new records from a shard, formatted as a time.Duration string.
+        description: Records polling period for the CDC mode of how often to get new records from a shard, formatted as a time.Duration string.
         type: duration
         default: 1s
         validations: []
       - name: skipSnapshot
-        description: skipSnapshot determines weather to skip the snapshot or not.
+        description: SkipSnapshot determines weather to skip the snapshot or not.
         type: bool
         default: "false"
         validations: []

--- a/connector.yaml
+++ b/connector.yaml
@@ -3,7 +3,7 @@ specification:
   name: dynamodb
   summary: A DynamoDB source plugin for Conduit
   description: A DynamoDB source plugin for Conduit, it scans the table at the beginning taking a snapshot, then starts listening to CDC events using DynamoDB streams.
-  version: (devel)
+  version: v0.3.0
   author: Meroxa, Inc.
   source:
     parameters:

--- a/connector.yaml
+++ b/connector.yaml
@@ -36,7 +36,9 @@ specification:
           - type: required
             value: ""
       - name: aws.sessionToken
-        description: AWS temporary session token.
+        description: |-
+          AWS temporary session token. Note that to keep the connector running long-term, you should use an IAM user with no temporary session token.
+          If the session token is used, then the connector will fail once it expires.
         type: string
         default: ""
         validations: []

--- a/connector.yaml
+++ b/connector.yaml
@@ -35,6 +35,11 @@ specification:
         validations:
           - type: required
             value: ""
+      - name: aws.sessionToken
+        description: AWS temporary session token.
+        type: string
+        default: ""
+        validations: []
       - name: aws.url
         description: AWSURL The URL for AWS (useful when testing the connector with localstack).
         type: string

--- a/source.go
+++ b/source.go
@@ -54,15 +54,16 @@ type SourceConfig struct {
 	AWSAccessKeyID string `json:"aws.accessKeyId" validate:"required"`
 	// AWS secret access key.
 	AWSSecretAccessKey string `json:"aws.secretAccessKey" validate:"required"`
-	// AWS temporary session token.
+	// AWS temporary session token. Note that to keep the connector running long-term, you should use an IAM user with no temporary session token.
+	// If the session token is used, then the connector will fail once it expires.
 	AWSSessionToken string `json:"aws.sessionToken"`
 	// AWSURL The URL for AWS (useful when testing the connector with localstack).
 	AWSURL string `json:"aws.url"`
-	// discovery polling period for the CDC mode of how often to check for new shards in the DynamoDB Stream, formatted as a time.Duration string.
+	// Discovery polling period for the CDC mode of how often to check for new shards in the DynamoDB Stream, formatted as a time.Duration string.
 	DiscoveryPollingPeriod time.Duration `json:"discoveryPollingPeriod" default:"10s"`
-	// records polling period for the CDC mode of how often to get new records from a shard, formatted as a time.Duration string.
+	// Records polling period for the CDC mode of how often to get new records from a shard, formatted as a time.Duration string.
 	RecordsPollingPeriod time.Duration `json:"recordsPollingPeriod" default:"1s"`
-	// skipSnapshot determines weather to skip the snapshot or not.
+	// SkipSnapshot determines weather to skip the snapshot or not.
 	SkipSnapshot bool `json:"skipSnapshot" default:"false"`
 }
 

--- a/source.go
+++ b/source.go
@@ -54,6 +54,8 @@ type SourceConfig struct {
 	AWSAccessKeyID string `json:"aws.accessKeyId" validate:"required"`
 	// AWS secret access key.
 	AWSSecretAccessKey string `json:"aws.secretAccessKey" validate:"required"`
+	// AWS temporary session token.
+	AWSSessionToken string `json:"aws.sessionToken"`
 	// AWSURL The URL for AWS (useful when testing the connector with localstack).
 	AWSURL string `json:"aws.url"`
 	// discovery polling period for the CDC mode of how often to check for new shards in the DynamoDB Stream, formatted as a time.Duration string.
@@ -83,7 +85,7 @@ func (s *Source) Open(ctx context.Context, pos opencdc.Position) error {
 
 	cfg, err := config.LoadDefaultConfig(ctx,
 		config.WithRegion(s.config.AWSRegion),
-		config.WithCredentialsProvider(aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(s.config.AWSAccessKeyID, s.config.AWSSecretAccessKey, ""))),
+		config.WithCredentialsProvider(aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(s.config.AWSAccessKeyID, s.config.AWSSecretAccessKey, s.config.AWSSessionToken))),
 	)
 	if err != nil {
 		return fmt.Errorf("could not load AWS config: %w", err)


### PR DESCRIPTION
### Description

Support using STS, with a temporary session token.

Note that to keep the connector running long-term, you should use IAM user with NO temporary session token. If the session token is used then the connector will fail once it expires.

### Quick checks:

- [ ] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-dynamodb/pulls) for the same update/change.
- [ ] I have written unit tests.
- [ ] I have made sure that the PR is of reasonable size and can be easily reviewed.