### PR TITLE
feat: Make AWS credentials optional with fallback to default credential chain

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,26 +42,36 @@ pipelines:
       - id: example
         plugin: "dynamodb"
         settings:
-          # AWS access key id.
-          # Type: string
-          # Required: yes
-          aws.accessKeyId: ""
           # AWS region.
           # Type: string
           # Required: yes
           aws.region: ""
-          # AWS secret access key.
-          # Type: string
-          # Required: yes
-          aws.secretAccessKey: ""
           # Table is the DynamoDB table name to pull data from.
           # Type: string
           # Required: yes
           table: ""
-          # AWS temporary session token. Note that to keep the connector running
-          # long-term, you should use an IAM user with no temporary session
-          # token. If the session token is used, then the connector will fail
-          # once it expires.
+          # AWS access key id. Optional - if not provided, the connector will
+          # use the default credential chain (environment variables, shared
+          # credentials file, or IAM role). For production environments, it's
+          # recommended to use the default credential chain with IAM roles
+          # rather than static credentials.
+          # Type: string
+          # Required: no
+          aws.accessKeyId: ""
+          # AWS secret access key. Optional - if not provided, the connector
+          # will use the default credential chain (environment variables, shared
+          # credentials file, or IAM role). For production environments, it's
+          # recommended to use the default credential chain with IAM roles
+          # rather than static credentials.
+          # Type: string
+          # Required: no
+          aws.secretAccessKey: ""
+          # AWS temporary session token. Optional - if not provided, the
+          # connector will use the default credential chain. Note that to keep
+          # the connector running long-term, you should use the default
+          # credential chain rather than temporary session tokens which will
+          # expire. For production environments, it's recommended to use IAM
+          # roles (IRSA, EC2 instance profile, or ECS task role).
           # Type: string
           # Required: no
           aws.sessionToken: ""

--- a/connector.yaml
+++ b/connector.yaml
@@ -3,26 +3,12 @@ specification:
   name: dynamodb
   summary: A DynamoDB source plugin for Conduit
   description: A DynamoDB source plugin for Conduit, it scans the table at the beginning taking a snapshot, then starts listening to CDC events using DynamoDB streams.
-  version: v0.3.0
+  version: v0.4.0
   author: Meroxa, Inc.
   source:
     parameters:
-      - name: aws.accessKeyId
-        description: AWS access key id.
-        type: string
-        default: ""
-        validations:
-          - type: required
-            value: ""
       - name: aws.region
         description: AWS region.
-        type: string
-        default: ""
-        validations:
-          - type: required
-            value: ""
-      - name: aws.secretAccessKey
-        description: AWS secret access key.
         type: string
         default: ""
         validations:
@@ -35,10 +21,28 @@ specification:
         validations:
           - type: required
             value: ""
+      - name: aws.accessKeyId
+        description: |-
+          AWS access key id. Optional - if not provided, the connector will use the default credential chain
+          (environment variables, shared credentials file, or IAM role). For production environments,
+          it's recommended to use the default credential chain with IAM roles rather than static credentials.
+        type: string
+        default: ""
+        validations: []
+      - name: aws.secretAccessKey
+        description: |-
+          AWS secret access key. Optional - if not provided, the connector will use the default credential chain
+          (environment variables, shared credentials file, or IAM role). For production environments,
+          it's recommended to use the default credential chain with IAM roles rather than static credentials.
+        type: string
+        default: ""
+        validations: []
       - name: aws.sessionToken
         description: |-
-          AWS temporary session token. Note that to keep the connector running long-term, you should use an IAM user with no temporary session token.
-          If the session token is used, then the connector will fail once it expires.
+          AWS temporary session token. Optional - if not provided, the connector will use the default credential chain.
+          Note that to keep the connector running long-term, you should use the default credential chain
+          rather than temporary session tokens which will expire. For production environments,
+          it's recommended to use IAM roles (IRSA, EC2 instance profile, or ECS task role).
         type: string
         default: ""
         validations: []

--- a/source.go
+++ b/source.go
@@ -73,6 +73,30 @@ type SourceConfig struct {
 	SkipSnapshot bool `json:"skipSnapshot" default:"false"`
 }
 
+// AWSLoadOpts returns the AWS configuration options based on the source config.
+func (c SourceConfig) AWSLoadOpts() []func(*config.LoadOptions) error {
+	opts := []func(*config.LoadOptions) error{
+		config.WithRegion(c.AWSRegion),
+	}
+
+	// Only use static credentials if both access key and secret are provided
+	if c.AWSAccessKeyID != "" && c.AWSSecretAccessKey != "" {
+		opts = append(opts,
+			config.WithCredentialsProvider(
+				aws.NewCredentialsCache(
+					credentials.NewStaticCredentialsProvider(
+						c.AWSAccessKeyID,
+						c.AWSSecretAccessKey,
+						c.AWSSessionToken,
+					),
+				),
+			),
+		)
+	}
+
+	return opts
+}
+
 type Iterator interface {
 	HasNext(ctx context.Context) bool
 	Next(ctx context.Context) (opencdc.Record, error)
@@ -90,28 +114,8 @@ func (s *Source) Config() sdk.SourceConfig {
 func (s *Source) Open(ctx context.Context, pos opencdc.Position) error {
 	sdk.Logger(ctx).Info().Msg("Opening DynamoDB Source...")
 
-	// Build up LoadDefaultConfig options
-	opts := []func(*config.LoadOptions) error{
-		config.WithRegion(s.config.AWSRegion),
-	}
-
-	// Only use static credentials if both access key and secret are provided
-	if s.config.AWSAccessKeyID != "" && s.config.AWSSecretAccessKey != "" {
-		opts = append(opts,
-			config.WithCredentialsProvider(
-				aws.NewCredentialsCache(
-					credentials.NewStaticCredentialsProvider(
-						s.config.AWSAccessKeyID,
-						s.config.AWSSecretAccessKey,
-						s.config.AWSSessionToken,
-					),
-				),
-			),
-		)
-	}
-
-	// When the static credentials are empty, falling back to use AWS config LoadDefaultConfig's default chain.
-	cfg, err := config.LoadDefaultConfig(ctx, opts...)
+	// Load AWS config with options from source config
+	cfg, err := config.LoadDefaultConfig(ctx, s.config.AWSLoadOpts()...)
 	if err != nil {
 		return fmt.Errorf("could not load AWS config: %w", err)
 	}

--- a/source.go
+++ b/source.go
@@ -50,12 +50,18 @@ type SourceConfig struct {
 	Table string `json:"table" validate:"required"`
 	// AWS region.
 	AWSRegion string `json:"aws.region" validate:"required"`
-	// AWS access key id.
-	AWSAccessKeyID string `json:"aws.accessKeyId" validate:"required"`
-	// AWS secret access key.
-	AWSSecretAccessKey string `json:"aws.secretAccessKey" validate:"required"`
-	// AWS temporary session token. Note that to keep the connector running long-term, you should use an IAM user with no temporary session token.
-	// If the session token is used, then the connector will fail once it expires.
+	// AWS access key id. Optional - if not provided, the connector will use the default credential chain
+	// (environment variables, shared credentials file, or IAM role). For production environments,
+	// it's recommended to use the default credential chain with IAM roles rather than static credentials.
+	AWSAccessKeyID string `json:"aws.accessKeyId"`
+	// AWS secret access key. Optional - if not provided, the connector will use the default credential chain
+	// (environment variables, shared credentials file, or IAM role). For production environments,
+	// it's recommended to use the default credential chain with IAM roles rather than static credentials.
+	AWSSecretAccessKey string `json:"aws.secretAccessKey"`
+	// AWS temporary session token. Optional - if not provided, the connector will use the default credential chain.
+	// Note that to keep the connector running long-term, you should use the default credential chain
+	// rather than temporary session tokens which will expire. For production environments,
+	// it's recommended to use IAM roles (IRSA, EC2 instance profile, or ECS task role).
 	AWSSessionToken string `json:"aws.sessionToken"`
 	// AWSURL The URL for AWS (useful when testing the connector with localstack).
 	AWSURL string `json:"aws.url"`
@@ -84,10 +90,28 @@ func (s *Source) Config() sdk.SourceConfig {
 func (s *Source) Open(ctx context.Context, pos opencdc.Position) error {
 	sdk.Logger(ctx).Info().Msg("Opening DynamoDB Source...")
 
-	cfg, err := config.LoadDefaultConfig(ctx,
+	// Build up LoadDefaultConfig options
+	opts := []func(*config.LoadOptions) error{
 		config.WithRegion(s.config.AWSRegion),
-		config.WithCredentialsProvider(aws.NewCredentialsCache(credentials.NewStaticCredentialsProvider(s.config.AWSAccessKeyID, s.config.AWSSecretAccessKey, s.config.AWSSessionToken))),
-	)
+	}
+
+	// Only use static credentials if both access key and secret are provided
+	if s.config.AWSAccessKeyID != "" && s.config.AWSSecretAccessKey != "" {
+		opts = append(opts,
+			config.WithCredentialsProvider(
+				aws.NewCredentialsCache(
+					credentials.NewStaticCredentialsProvider(
+						s.config.AWSAccessKeyID,
+						s.config.AWSSecretAccessKey,
+						s.config.AWSSessionToken,
+					),
+				),
+			),
+		)
+	}
+
+	// When the static credentials are empty, falling back to use AWS config LoadDefaultConfig's default chain.
+	cfg, err := config.LoadDefaultConfig(ctx, opts...)
 	if err != nil {
 		return fmt.Errorf("could not load AWS config: %w", err)
 	}


### PR DESCRIPTION
### Description

- Make the AWS credential fields optional in our pipeline YAML and code schema.

- Wrap the [WithCredentialsProvider(...)](https://github.com/conduitio-labs/conduit-connector-dynamodb/blob/add468bb2242ff9809e1b20506633c297352eb1c/source.go#L89) logic so it only applies when those fields are non-empty, otherwise falling back to[ LoadDefaultConfig’s default chain](https://docs.aws.amazon.com/sdk-for-go/v2/developer-guide/configure-gosdk.html#specifying-credentials).

- Update the README/examples to mark those fields “optional” and add a note about IRSA (or env/shared-file) as the recommended production approach.

This change allows the connector to authenticate with AWS using either static credentials or AWS default config chain, providing more flexibility in how the connector accesses DynamoDB resources.

### Testing

Tested locally by dropping the aws.accessKeyId and aws.secretAccessKey fields from our connector and instead exporting them in my ~/.zshrc. The [AWS SDK for Go v2](https://github.com/aws/aws-sdk-go-v2) picked them up automatically and authenticated successfully.

<img width="1271" alt="Screenshot 2025-05-14 at 1 48 19 PM" src="https://github.com/user-attachments/assets/5bc84c7f-0fb1-42fa-bb8e-3f050d119355" />

<details>
<summary> Passed integration test
</summary>

```
% make test-integration
docker compose -f test/docker-compose.yml up --quiet-pull -d --wait
[+] Running 2/2
 ✔ Network test_default         Created                                                                                               0.0s 
 ✔ Container test-localstack-1  Healthy                                                                                              11.7s 
go test  -v -race ./...; ret=$?; \
                docker compose -f test/docker-compose.yml down -v; \
                exit $ret
=== RUN   TestSource_SuccessfulSnapshot
Table conduit-dynamodb-source-test-144e8011-2bcf-410d-a295-88bbbfe39894 is now active.
--- PASS: TestSource_SuccessfulSnapshot (8.34s)
=== RUN   TestSource_SnapshotRestart
Table conduit-dynamodb-source-test-1a301971-d1ff-4510-bb33-7a5fbcb1ce08 is now active.
--- PASS: TestSource_SnapshotRestart (5.15s)
=== RUN   TestSource_EmptyTable
Table conduit-dynamodb-source-test-2fdf1d41-f3bc-4c9c-bb19-9b9c28b0b3a7 is now active.
--- PASS: TestSource_EmptyTable (11.18s)
=== RUN   TestSource_NonExistentTable
Table conduit-dynamodb-source-test-7e7446a5-6be7-40ef-81da-6915a6f2dc99 is now active.
--- PASS: TestSource_NonExistentTable (0.04s)
=== RUN   TestSource_CDC
Table conduit-dynamodb-source-test-2e8ff876-a39f-407c-bedc-94683cb5f2a7 is now active.
--- PASS: TestSource_CDC (11.16s)
PASS
ok      github.com/conduitio-labs/conduit-connector-dynamodb    37.546s
?       github.com/conduitio-labs/conduit-connector-dynamodb/cmd/connector      [no test files]
?       github.com/conduitio-labs/conduit-connector-dynamodb/iterator   [no test files]
=== RUN   TestParseSDKPosition
=== RUN   TestParseSDKPosition/valid_position
=== RUN   TestParseSDKPosition/unknown_iterator_type
=== RUN   TestParseSDKPosition/nil_position
--- PASS: TestParseSDKPosition (0.00s)
    --- PASS: TestParseSDKPosition/valid_position (0.00s)
    --- PASS: TestParseSDKPosition/unknown_iterator_type (0.00s)
    --- PASS: TestParseSDKPosition/nil_position (0.00s)
PASS
ok      github.com/conduitio-labs/conduit-connector-dynamodb/position   1.773s
[+] Running 2/2
 ✔ Container test-localstack-1  Removed                                                                                               2.5s 
 ✔ Network test_default         Removed        
```

</details>

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-dynamodb/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.