### PR TITLE
feat: Support Assuming AWS Role using Service Account Credentials, i.e. IRSA on EKS

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,11 @@ pipelines:
           # Type: string
           # Required: no
           aws.accessKeyId: ""
+          # AWS AssumeRoleChain. Optional - if not provided, the connector will
+          # use the default credential chain.
+          # Type: string
+          # Required: no
+          aws.assumeRoleArn: ""
           # AWS secret access key. Optional - if not provided, the connector
           # will use the default credential chain (environment variables, shared
           # credentials file, or IAM role). For production environments, it's
@@ -179,6 +184,11 @@ pipelines:
           # Type: string
           # Required: no
           aws.accessKeyId: ""
+          # AWS AssumeRoleChain. Optional - if not provided, the connector will
+          # use the default credential chain.
+          # Type: string
+          # Required: no
+          aws.assumeRoleArn: ""
           # AWS secret access key. Optional - if not provided, the connector
           # will use the default credential chain (environment variables, shared
           # credentials file, or IAM role). For production environments, it's

--- a/config.go
+++ b/config.go
@@ -37,4 +37,6 @@ type Config struct {
 	AWSSessionToken string `json:"aws.sessionToken"`
 	// The URL for AWS (useful when testing the connector with localstack).
 	AWSURL string `json:"aws.url"`
+	// AWS AssumeRoleChain. Optional - if not provided, the connector will use the default credential chain.
+	AWSAssumeRoleArn string `json:"aws.assumeRoleArn"`
 }

--- a/connector.yaml
+++ b/connector.yaml
@@ -50,6 +50,11 @@ specification:
         type: string
         default: ""
         validations: []
+      - name: aws.assumeRoleArn
+        description: AWS AssumeRoleChain. Optional - if not provided, the connector will use the default credential chain.
+        type: string
+        default: ""
+        validations: []
       - name: aws.secretAccessKey
         description: |-
           AWS secret access key. Optional - if not provided, the connector will use the default credential chain
@@ -168,6 +173,11 @@ specification:
           AWS access key id. Optional - if not provided, the connector will use the default credential chain
           (environment variables, shared credentials file, or IAM role). For production environments,
           it's recommended to use the default credential chain with IAM roles rather than static credentials.
+        type: string
+        default: ""
+        validations: []
+      - name: aws.assumeRoleArn
+        description: AWS AssumeRoleChain. Optional - if not provided, the connector will use the default credential chain.
         type: string
         default: ""
         validations: []

--- a/go.mod
+++ b/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.25.5
+	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0
 	github.com/aws/smithy-go v1.22.4
 	github.com/conduitio/conduit-commons v0.6.0
 	github.com/conduitio/conduit-connector-sdk v0.14.1
@@ -49,7 +50,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.12.17 // indirect
 	github.com/aws/aws-sdk-go-v2/service/sso v1.25.5 // indirect
 	github.com/aws/aws-sdk-go-v2/service/ssooidc v1.30.3 // indirect
-	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/bkielbasa/cyclop v1.2.3 // indirect
 	github.com/blizzy78/varnamelen v0.8.0 // indirect

--- a/source.go
+++ b/source.go
@@ -80,17 +80,17 @@ func (c SourceConfig) AWSLoadOpts() []func(*config.LoadOptions) error {
 	}
 
 	if c.AWSAssumeRoleArn != "" {
-        opts = append(opts, func(lo *config.LoadOptions) error {
-            // lo.Credentials：the service account role
-            stsc := sts.NewFromConfig(aws.Config{
-                Region:      c.AWSRegion,
-                Credentials: lo.Credentials,
-            })
-            provider := stscreds.NewAssumeRoleProvider(stsc, c.AWSAssumeRoleArn)
-            lo.Credentials = aws.NewCredentialsCache(provider)
-            return nil
-        })
-    }
+		opts = append(opts, func(lo *config.LoadOptions) error {
+			// lo.Credentials：the service account role
+			stsc := sts.NewFromConfig(aws.Config{
+				Region:      c.AWSRegion,
+				Credentials: lo.Credentials,
+			})
+			provider := stscreds.NewAssumeRoleProvider(stsc, c.AWSAssumeRoleArn)
+			lo.Credentials = aws.NewCredentialsCache(provider)
+			return nil
+		})
+	}
 
 	return opts
 }


### PR DESCRIPTION
### Description

This pull request introduces support for assuming an AWS IAM role using the `AssumeRole` mechanism.
- Updated imports to include `stscreds` and `sts` packages for AWS STS functionality.
- Modified the `AWSLoadOpts` method to handle the `aws.assumeRoleArn` parameter. If specified, it sets up the `AssumeRoleProvider` to assume the given IAM role and updates the credentials cache accordingly.
- Modify `AWSLoadOpts` to enable assuming a single target role (e.g., across AWS accounts) by using the current service's IAM role or environment credentials as the source.
- If `AWSAssumeRoleArn` is set in config, all AWS SDK operations now use credentials automatically assumed from that role.
- Ensures correct role is assumed at config load time, improving cross-account access and compatibility with deployments using service accounts (EC2, ECS, EKS, etc).

### KnowWhy

There are scenarios where cross-account resource access is needed, for instance, Conduit application in AWS account_a needs to access the DynamoDB tables in account_b. Adding the `AssumeRole` mechanism allows Conduit IRSA to assume an authenticated role in account_b without needing to add additional infrastructure resources (e.g. customer KMS key [ref](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/EncryptionAtRest.html)) and define custom resource-based policy in account_b. 

### Testing Plan
- Tested with `aws.assumeRoleArn: "xxx"` locally for cross-account access (service account_a assumes service account_b). 

```
2025-07-09T20:43:53+00:00 INF component=plugin connector_id=example:example-destination plugin_name=log plugin_type=destination record="xxxxx" ... 
```

- Tested with empty `aws.assumeRoleArn: ""` locally for same-account access, the AWS default credential chain still works. 

```
2025-07-09T21:11:57+00:00 INF component=plugin connector_id=example:example-destination plugin_name=log plugin_type=destination record={"key":...
```

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-dynamodb/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.