### PR TITLE
Fix: use built-in WithAssumeRoleCredentialOptions for assume-role support

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.70
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.44.0
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.26.0
-	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0
+	github.com/aws/aws-sdk-go-v2/service/sts v1.34.0 // indirect
 	github.com/aws/smithy-go v1.22.4
 	github.com/conduitio/conduit-commons v0.6.0
 	github.com/conduitio/conduit-connector-sdk v0.14.1


### PR DESCRIPTION
### Description
Previously (PR #188) I created a temporary `aws.Config` and manually wrapped `lo.Credentials` with an STS provider. That approach unintentionally overrode all of the [aws-sdk-go-v2](https://github.com/aws/aws-sdk-go-v2)’s default settings (HTTPClient, retryer, logger, endpoint resolution, SSO, etc.) and dropped support for the full set of `AssumeRole` options.

This commit:
- Removes the custom `sts.NewFromConfig` + manual `lo.Credentials` wrapper
- Uses `config.WithAssumeRoleCredentialOptions(...)` to inject the role ARN and any optional parameters (ExternalID, Duration, SessionName, etc.)
- Preserves the SDK’s defaults for HTTPClient, retryer, logger, endpoint resolver, SSO, and other config
- Simplifies code and aligns with the AWS SDK v2 recommended pattern

Fixes # (issue)
- https://github.com/conduitio-labs/conduit-connector-dynamodb/pull/188

### Testing Plan
- Verified IRSA-based assumeRole in local k8s container
- Verified static creds (accessKeyId/secretAccessKey/sessionToken) locally

```
2025-07-16T13:29:18+00:00 INF component=plugin connector_id=example:example-destination plugin_name=log plugin_type=destination record={"key":{"KEY":"hello-week"},"metadata":{"conduit.source.connector.id":
```

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-dynamodb/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.