### PR TITLE
fix: support AssumeRole for AWS credentials in SourceConfig

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/aws/aws-sdk-go-v2/credentials v1.17.71
 	github.com/aws/aws-sdk-go-v2/service/dynamodb v1.44.1
 	github.com/aws/aws-sdk-go-v2/service/dynamodbstreams v1.26.0
-	github.com/aws/aws-sdk-go-v2/service/sts v1.34.1 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sts v1.34.1
 	github.com/aws/smithy-go v1.22.4
 	github.com/conduitio/conduit-commons v0.6.0
 	github.com/conduitio/conduit-connector-sdk v0.14.1

--- a/source.go
+++ b/source.go
@@ -84,12 +84,11 @@ func (c SourceConfig) AWSLoadOpts(ctx context.Context) ([]func(*config.LoadOptio
 		// Load default AWS config with our options
 		cfg, err := config.LoadDefaultConfig(ctx, opts...)
 		if err != nil {
-			return nil, fmt.Errorf("Error loading AWS config for AWS Assume Role: %w", err)
-		} else {
-			stsClient := sts.NewFromConfig(cfg)
-			assumeRoleProvider := stscreds.NewAssumeRoleProvider(stsClient, c.AWSAssumeRoleArn)
-			opts = append(opts, config.WithCredentialsProvider(aws.NewCredentialsCache(assumeRoleProvider)))
+			return nil, fmt.Errorf("error loading AWS config for AWS Assume Role: %w", err)
 		}
+		stsClient := sts.NewFromConfig(cfg)
+		assumeRoleProvider := stscreds.NewAssumeRoleProvider(stsClient, c.AWSAssumeRoleArn)
+		opts = append(opts, config.WithCredentialsProvider(aws.NewCredentialsCache(assumeRoleProvider)))
 	}
 
 	return opts, nil

--- a/source.go
+++ b/source.go
@@ -59,7 +59,7 @@ type SourceConfig struct {
 }
 
 // AWSLoadOpts returns the AWS configuration options based on the source config.
-func (c SourceConfig) AWSLoadOpts() []func(*config.LoadOptions) error {
+func (c SourceConfig) AWSLoadOpts(ctx context.Context) []func(*config.LoadOptions) error {
 	opts := []func(*config.LoadOptions) error{
 		config.WithRegion(c.AWSRegion),
 	}
@@ -82,7 +82,7 @@ func (c SourceConfig) AWSLoadOpts() []func(*config.LoadOptions) error {
 	if c.AWSAssumeRoleArn != "" {
 		fmt.Println("Use assume role")
 		// Load default AWS config with our options
-		cfg, err := config.LoadDefaultConfig(context.Background(), opts...)
+		cfg, err := config.LoadDefaultConfig(ctx, opts...)
 		if err != nil {
 			fmt.Printf("Error loading AWS config: %v\n", err)
 		} else {
@@ -113,7 +113,7 @@ func (s *Source) Open(ctx context.Context, pos opencdc.Position) error {
 	sdk.Logger(ctx).Info().Msg("Opening DynamoDB Source...")
 
 	// Load AWS config with options from source config
-	cfg, err := config.LoadDefaultConfig(ctx, s.config.AWSLoadOpts()...)
+	cfg, err := config.LoadDefaultConfig(ctx, s.config.AWSLoadOpts(ctx)...)
 	if err != nil {
 		return fmt.Errorf("could not load AWS config: %w", err)
 	}

--- a/source.go
+++ b/source.go
@@ -80,11 +80,11 @@ func (c SourceConfig) AWSLoadOpts(ctx context.Context) []func(*config.LoadOption
 	}
 
 	if c.AWSAssumeRoleArn != "" {
-		fmt.Println("Use assume role")
+		sdk.Logger(ctx).Info().Msg("Use AWS Assume Role...")
 		// Load default AWS config with our options
 		cfg, err := config.LoadDefaultConfig(ctx, opts...)
 		if err != nil {
-			fmt.Printf("Error loading AWS config: %v\n", err)
+			fmt.Errorf("Error loading AWS config for AWS Assume Role: %w", err)
 		} else {
 			stsClient := sts.NewFromConfig(cfg)
 			assumeRoleProvider := stscreds.NewAssumeRoleProvider(stsClient, c.AWSAssumeRoleArn)


### PR DESCRIPTION
### Description

- Use stscreds.NewAssumeRoleProvider to enable AssumeRole when AWSAssumeRoleArn is set
- Fix AWSLoadOpts to properly set credentials provider for role assumption

### Testing Plan

- Tested in local k8s container with assumeRole. 

Fixes # (issue)

### Quick checks:

- [x] There is no other [pull request](https://github.com/conduitio-labs/conduit-connector-dynamodb/pulls) for the same update/change.
- [ ] I have written unit tests.
- [x] I have made sure that the PR is of reasonable size and can be easily reviewed.